### PR TITLE
Add alphabetical password handling

### DIFF
--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -27,7 +27,7 @@ class Main extends React.Component {
 		
 		const inputDesc = lessonSlides[this.state.lessonNum][this.state.count].inputDesc;
 		const inputLength = lessonSlides[this.state.lessonNum][this.state.count].inputLength;
-		const regexp = lessonSlides[this.state.lessonNum][this.state.count].regexp;
+		const checkInput = lessonSlides[this.state.lessonNum][this.state.count].checkInput;
 		
 		let newError;
 		let inputValid = true;
@@ -35,7 +35,7 @@ class Main extends React.Component {
 		if (this.state.value.length !== inputLength) {
 			inputValid = false;
 		}
-		if (!this.state.value.match(regexp)) {
+		if (!checkInput(this.state.value)) {
 			inputValid = false;
 		}
 

--- a/src/components/TextSlide/TextSlide.js
+++ b/src/components/TextSlide/TextSlide.js
@@ -4,13 +4,40 @@ import Slide from '@material-ui/core/Slide';
 import Grid from '@material-ui/core/Grid';
 import CountUp from 'react-countup';
 
+// function to convert a number to a string based on the given alphabet
+//    example: if alphabet is 'abc',
+//      0 -> 'a'
+//      1 -> 'b'
+//      2 -> 'c'
+//      3 -> 'aa'
+//      4 -> 'ab'
+//      5 -> 'ac'
+//      6 -> 'ba'
+//      ...
+function toLetters(num, alphabet) {
+  const mod = num % alphabet.length;
+  const pow = Math.floor(num / alphabet.length);
+  const out = alphabet[mod];
+  return pow ? toLetters(pow, alphabet) + out : out;
+}
+
+// function to convert a string to a number based on the given alphabet
+// see example for toLetters
+function fromLetters(str, alphabet) {
+  var out = 0, len = str.length, pos = len;
+  while (--pos > -1) {
+      out += (alphabet.indexOf(str[pos])) * Math.pow(alphabet.length, len - 1 - pos);
+  }
+  return out;
+}
+
 export default function TextSlide(props) {
   const passwordGuesser = (
     (props.usesInput !== true) ? null :
     (props.inputType === 'num') ? (
       <CountUp
         start={0}
-        duration={1/10000 * parseInt(props.userInput, 10)}
+        duration={parseInt(props.userInput, 10) / 10000}
         end={parseInt(props.userInput, 10)}
         formattingFn={num => String(num).padStart(props.inputLength, '0')}
         useEasing={false}>

--- a/src/components/TextSlide/TextSlide.js
+++ b/src/components/TextSlide/TextSlide.js
@@ -31,6 +31,11 @@ function fromLetters(str, alphabet) {
   return out;
 }
 
+// const alpha_lower = 'abcdefghijklmnopqrstuvwxyz';
+// const alpha_mixed = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const vowels_lower = 'aeiou';
+const vowels_mixed = 'aeiouAEIOU';
+
 export default function TextSlide(props) {
   const passwordGuesser = (
     (props.usesInput !== true) ? null :
@@ -47,7 +52,37 @@ export default function TextSlide(props) {
             <Button onClick={start}>Start</Button>
           </div>
         )}
-      </CountUp>) : null
+      </CountUp>) : 
+    (props.inputType === 'vowels') ? (
+      <CountUp
+        start={0}
+        duration={fromLetters(props.userInput, vowels_lower) / 10000}
+        end={fromLetters(props.userInput, vowels_lower)}
+        formattingFn={num => toLetters(num, vowels_lower).padStart(props.inputLength, vowels_lower[0])}
+        useEasing={false}>
+          {({ countUpRef, start }) => (
+          <div>
+            <span ref={countUpRef} />
+            <Button onClick={start}>Start</Button>
+          </div>
+        )}
+      </CountUp>
+    ) : 
+    (props.inputType === 'Vowels') ? (
+      <CountUp
+        start={0}
+        duration={fromLetters(props.userInput, vowels_mixed) / 10000}
+        end={fromLetters(props.userInput, vowels_mixed)}
+        formattingFn={num => toLetters(num, vowels_mixed).padStart(props.inputLength, vowels_mixed[0])}
+        useEasing={false}>
+          {({ countUpRef, start }) => (
+          <div>
+            <span ref={countUpRef} />
+            <Button onClick={start}>Start</Button>
+          </div>
+        )}
+      </CountUp>
+    ) : null
   );
 
   const slidingItems = props.lessonItems.map((item, i) => {

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -4,10 +4,10 @@ import Typography from '@material-ui/core/Typography';
 /** keys and fields:
  *  slide: the text that should appear
  *  input: true if slide requires user input
- *  inputType: 'num', 'alpha', 
- *  inputDesc: describes the expected type of the user's input
- *  inputLength: the required length of the user's input
- *  regexp: regular expression matching the accepted inputs
+ *  inputType: 'num', 'vowels', 'Vowels'
+ *  inputDesc: a more verbose description the expected type of the user's input
+ *  inputLength: the required/expected length of the user's input
+ *  checkInput: predicate that returns true if input was valid, false otherwise
  *  usesInput: true if slide requires result of last user input
  */   
 export const lessonSlides = [
@@ -59,6 +59,11 @@ export const lessonSlides = [
     }
   ],
   [
+    // The lesson uses just vowels instead of the full a-z set of characters. This
+    // is to reduce the size of the alphabet and thus add more flexibility with
+    // the length of passwords we can generate in a reasonable time. Also, just
+    // using vowels (as opposed to a full alphabet or just consonants) circumvents
+    // the need to check for profanity.
     { 
       slide: <Typography>You’ll often see sites recommend that you use
         uppercase letters, numbers, and symbols in your password. Why is that?

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -20,7 +20,7 @@ export const lessonSlides = [
       inputType: 'num',
       inputDesc: 'digits',
       inputLength: 4,
-      regexp: /^\d{4}$/
+      checkInput: str => /^\d{4}$/.test(str)
     },
     {
       slide: <Typography>Press start to see how long it takes for a computer to
@@ -38,20 +38,74 @@ export const lessonSlides = [
       inputType: 'num',
       inputDesc: 'digits',
       inputLength: 6,
-      regexp: /^\d{6}$/
+      checkInput: str => /^\d{6}$/.test(str)
     },
     { 
       slide: <Typography>Let's see how long it takes for the computer
-        to guess your 6-digit password!
+        to guess your 6-digit password! This might take a while, so feel free
+        to click the next button if you're tired of waiting :)
       </Typography>,
       usesInput: true,
       inputType: 'num',
       inputLength: 6
+    },
+    {
+      slide: <Typography>Though it depends somewhat on which numbers you
+        picked for your passwords, you should have noticed that the 6-digit
+        password took a lot longer to crack than the 4-digit password! This is
+        because there are many more possible values you can make with 6 digits
+        compared to with 4 digits.
+      </Typography>
     }
   ],
   [
-    { slide: <Typography>Goodbye, world!</Typography>},
-    { slide: <Typography>You finished our passworks lesson!</Typography>},
-    { slide: <Typography>We hope you had fun :)</Typography>}
+    { 
+      slide: <Typography>You’ll often see sites recommend that you use
+        uppercase letters, numbers, and symbols in your password. Why is that?
+        </Typography>
+    },
+    { 
+      slide: <Typography>Try submitting a 6-letter password with just lowercase
+        vowels (a e i o u), and we'll see how long it takes for the computer to guess it!
+        </Typography>,
+      input: true,
+      inputType: 'vowels',
+      inputDesc: 'lowercase vowels',
+      inputLength: 6,
+      checkInput: str => /^[aeiou]{6}$/.test(str)
+    },
+    { 
+      slide: <Typography>Press start to see how long it takes for a computer to
+        guess your 6-letter lowercase password!
+        </Typography>,
+      usesInput: true,
+      inputType: 'vowels',
+      inputLength: 6
+    },
+    { 
+      slide: <Typography>Now try submitting another 6-vowel password, this time
+        mixing lowercase and uppercase vowels (a e i o u A E I O U). Include at
+        least one uppercase vowel!
+        </Typography>,
+      input: true,
+      inputType: 'Vowels',
+      inputDesc: 'mixed upper and lower case vowels',
+      inputLength: 6,
+      checkInput: str => /.*[AEIOU].*/.test(str) && /^[aeiouAEIOU]{6}$/.test(str)
+    },
+    { 
+      slide: <Typography>Press start to see how long it takes for a computer to
+        guess your 6-letter mixed-case password!
+        </Typography>,
+      usesInput: true,
+      inputType: 'Vowels',
+      inputLength: 6
+    },
+    {
+      slide: <Typography>Hopefully, you saw that the mixed-case password took
+        longer to generate! This is because when we introduce more character
+        variety, there are more possible passwords that can be generated!
+      </Typography>
+    }
   ]
 ];


### PR DESCRIPTION
Adds a lesson to demonstrate the importance of mixing character types (lowercase + uppercase).

The lesson uses just vowels instead of the full a-z set of characters. This is to reduce the size of the alphabet and thus add more flexibility with the length of passwords we can generate in a reasonable time. Also, just using vowels (as opposed to a full alphabet or just consonants) circumvents the need to check for profanity.

The alphabet used can be changed easily later on if we decide to.