### PR TITLE
Put common password input and result on phone

### DIFF
--- a/src/components/CommonPassword/CommonPassword.js
+++ b/src/components/CommonPassword/CommonPassword.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
+
+import commonPws from '../../constants/common.json';
+const commonPasswords = new Set(commonPws);
+
+const useStyles = () => ({
+	inputText: {
+		margin: '4px', 
+		padding: '8px',
+		borderRadius: '4px',
+		fontFamily: '"Chivo"',
+		fontSize: '1em'
+	}
+});
+
+class CommonPassword extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: '',
+      password: '',
+      inputLength: 0,
+      inputError: false,
+      errorString: 'Please enter a password with 4 or more characters'
+    };
+  }
+
+  handleInputChange = event => {
+    this.setState({value: event.target.value, inputLength: event.target.value.length});
+  }
+
+  handleInputSubmit = event => {
+    event.preventDefault();
+    if (this.state.inputLength < 4) {
+      this.setState({ value: '', inputLength: 0, inputError: true });
+    } else {
+      this.setState({ password: this.state.value, value: '', inputError: false });
+    }
+  }
+
+  renderResult = () => {
+    if (this.state.password === '') {
+      return null;
+    } else {
+      if (commonPasswords.has(this.state.password)) {
+        return (
+          <Typography variant={'body1'} style={{ textAlign: 'center' }}>
+            Oh no! The password you typed is in the top 10,000 most common passwords.
+          </Typography>
+        );
+      } else {
+        return (
+          <Typography variant={'body1'} style={{ textAlign: 'center' }}>
+            Yay! The password you typed is not in the top 10,000 most common passwords.
+          </Typography>
+        );
+      }
+    }
+  }
+
+  render () {
+    const { classes } = this.props;
+
+    return (
+      <>
+        <form onSubmit={this.handleInputSubmit}>
+          <Box display='flex' flexDirection='column' alignItems='center'>
+            <input type='text' className={classes.inputText}
+              value={this.state.value} onChange={this.handleInputChange} />
+            <Typography color='error' style={{ textAlign: 'center' }}>
+              {this.state.inputError ? this.state.errorString : null}
+            </Typography>
+            <Button disableRipple variant='outlined' type='submit'>Submit</Button>
+          </Box>
+        </form>
+        {this.renderResult()}
+      </>
+    );
+  }
+}
+
+export default withStyles(useStyles)(CommonPassword);

--- a/src/components/PasswordGuesser/PasswordGuesser.js
+++ b/src/components/PasswordGuesser/PasswordGuesser.js
@@ -2,11 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import CountUp from 'react-countup';
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 import makeStyles from '@material-ui/core/styles/makeStyles';
-
-import commonPws from '../../constants/common.json';
-const commonPasswords = new Set(commonPws);
 
 // function to convert a number to a string based on the given alphabet
 //    example: if alphabet is 'abc',
@@ -118,15 +114,6 @@ export default function PasswordGuesser(props) {
           )}
         </CountUp>
       </Box>
-    ) :
-    (props.inputType === 'common') ? (
-      commonPasswords.has(props.userInput) ? (
-        <Typography variant={'body1'} className={classes.text}>
-          Oh no! The password you typed is in the top 10,000 most common passwords.
-        </Typography>) :
-        <Typography variant={'body1'} className={classes.text}>
-          Yay! The password you typed is not in the top 10,000 most common passwords.
-        </Typography>
     ) : null
   );
 

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -4,6 +4,7 @@ import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 import PasswordGuesser from '../components/PasswordGuesser/PasswordGuesser.js';
 import Profile from '../components/Profile/Profile.js';
+import CommonPassword from '../components/CommonPassword/CommonPassword.js';
 
 const guesser = (userInput, inputType, inputLength) => {
   return (
@@ -170,20 +171,8 @@ export const allLessons = [
     { 
       slide: <>Try experimenting with submitting passwords (of 4 or
         more characters) and seeing which ones are in the list of the 10,000 most
-        common passwords.
-      </>,
-      input: true,
-      inputType: 'common',
-      inputDesc: 'a password with 4 or more characters',
-      inputLength: -1,
-      checkInput: str => /^.{4,}$/.test(str),
-      phoneContent: inputForm
-    },
-    {
-      usesInput: true,
-      inputType: 'common',
-      inputLength: -1,
-      phoneContent: guesser
+        common passwords.</>,
+      phoneContent: () => <CommonPassword />
     },
     {
       slide: <>Though it's a good sign if your password isn't in the list,


### PR DESCRIPTION
Fixes: #12 

Changes the common password lesson to have the password input and result on the same slide on the phone screen.

![image](https://user-images.githubusercontent.com/35614552/84922219-8d911c80-b093-11ea-8924-dcc2f132358c.png)
![image](https://user-images.githubusercontent.com/35614552/84922230-8ff37680-b093-11ea-8824-e2bef0fe7e2b.png)
![image](https://user-images.githubusercontent.com/35614552/84922240-9386fd80-b093-11ea-9090-630306a86d2f.png)
