### PR TITLE
Add time difference slide

### DIFF
--- a/src/components/LessonText/LessonText.js
+++ b/src/components/LessonText/LessonText.js
@@ -12,11 +12,11 @@ class LessonText extends React.Component {
     const isLastLesson = lessonNum === allLessons.length - 1
     const isLastSlide = count === allLessons[lessonNum].length - 1
     const isInputSlide = allLessons[lessonNum][count].input
-    const { usesInput } = allLessons[lessonNum][count]
+    const isFirstSlide = count === 0
 
     const renderNextLesson = !isLastLesson && isLastSlide
     const renderNext = !isLastSlide && !isInputSlide
-    const renderBack = usesInput
+    const renderBack = !isFirstSlide
     const renderEnd = isLastLesson && isLastSlide
 
     const nextLessonButton = (
@@ -47,7 +47,7 @@ class LessonText extends React.Component {
         disableRipple
         variant="outlined"
         onClick={() => {
-          setLessonAndCount(lessonNum, count - 1)
+          setCount(count - 1)
         }}
       >
         Back

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -44,7 +44,8 @@ class Main extends React.Component {
       count: 0,
       lessonNum: 0,
       value: "",
-      userInput: "",
+      userInput1: "",
+      userInput2: "",
       inputLength: 0,
       inputError: false,
       errorString: "",
@@ -62,8 +63,8 @@ class Main extends React.Component {
     event.preventDefault()
     const { lessonNum, count, value } = this.state
 
-    const { inputDesc } = allLessons[lessonNum][count]
-    const { checkInput } = allLessons[lessonNum][count]
+    const { inputDesc, checkInput, inputNum } = allLessons[lessonNum][count]
+    const inputNumber = inputNum === 2 ? 2 : 1
 
     let newError
     let inputValid = true
@@ -76,8 +77,12 @@ class Main extends React.Component {
       newError = `Please enter ${inputDesc}.`
       this.setState({ value: "", errorString: newError, inputError: true })
     } else {
+      if (inputNumber === 2) {
+        this.setState({ userInput2: value })
+      } else {
+        this.setState({ userInput1: value })
+      }
       this.setState({
-        userInput: value,
         inputLength: value.length,
         value: "",
         inputError: false,
@@ -99,7 +104,8 @@ class Main extends React.Component {
     this.setState({
       lessonNum: newLessonNum,
       value: "",
-      userInput: "",
+      userInput1: "",
+      userInput2: "",
       inputLength: 0,
       errorString: "",
       inputError: false,
@@ -163,7 +169,12 @@ class Main extends React.Component {
             className={i === lessonNum ? classes.selectedLesson : null}
             onClick={() => {
               this.setLessonAndCount(i, 0)
-              this.setState({ userInput: "", value: "", inputLength: 0 })
+              this.setState({
+                userInput1: "",
+                userInput2: "",
+                value: "",
+                inputLength: 0,
+              })
             }}
           >
             {lesson[0].title}
@@ -190,15 +201,15 @@ class Main extends React.Component {
   render() {
     const { lessonNum, count, value, inputError, errorString } = this.state
     const { classes } = this.props
-    const { userInput } = this.state
-    const { inputType } = allLessons[lessonNum][count]
-    const { inputLength } = this.state
+    const { userInput1, userInput2, inputLength } = this.state
+    const { inputType, usesInput2 } = allLessons[lessonNum][count]
 
     let phoneContent
     const renderPhoneContent = allLessons[lessonNum][count].phoneContent
     if (renderPhoneContent === null) {
       phoneContent = null
     } else if (allLessons[lessonNum][count].input) {
+      // render randomize button
       let randomButton
       if ("defaultInput" in allLessons[lessonNum][count]) {
         randomButton = (
@@ -218,6 +229,7 @@ class Main extends React.Component {
       } else {
         randomButton = null
       }
+      // render input form
       phoneContent = renderPhoneContent(
         classes,
         value,
@@ -228,9 +240,12 @@ class Main extends React.Component {
         randomButton
       )
     } else if (allLessons[lessonNum][count].comparison) {
+      // render math comparison
       phoneContent = renderPhoneContent(inputLength)
     } else {
-      phoneContent = renderPhoneContent(userInput, inputType, inputLength)
+      // chat, profile, commonpassword, or guesser
+      const userInput = usesInput2 ? userInput2 : userInput1
+      phoneContent = renderPhoneContent(userInput, inputType)
     }
 
     return (

--- a/src/components/Main/Main.js
+++ b/src/components/Main/Main.js
@@ -242,6 +242,9 @@ class Main extends React.Component {
     } else if (allLessons[lessonNum][count].comparison) {
       // render math comparison
       phoneContent = renderPhoneContent(inputLength)
+    } else if (allLessons[lessonNum][count].timeDifference) {
+      // time difference
+      phoneContent = renderPhoneContent(userInput1, userInput2)
     } else {
       // chat, profile, commonpassword, or guesser
       const userInput = usesInput2 ? userInput2 : userInput1

--- a/src/components/PasswordGuesser/PasswordGuesser.js
+++ b/src/components/PasswordGuesser/PasswordGuesser.js
@@ -3,39 +3,12 @@ import PropTypes from "prop-types"
 import Typography from "@material-ui/core/Typography"
 
 import GuesserAndTimer from "./GuesserAndTimer/GuesserAndTimer"
-
-// function to convert a number to a string based on the given alphabet
-//    example: if alphabet is 'abc',
-//      0 -> 'a'
-//      1 -> 'b'
-//      2 -> 'c'
-//      3 -> 'aa'
-//      4 -> 'ab'
-//      5 -> 'ac'
-//      6 -> 'ba'
-//      ...
-function toLetters(num, alphabet) {
-  const mod = num % alphabet.length
-  const pow = Math.floor(num / alphabet.length)
-  const out = alphabet[mod]
-  return pow ? toLetters(pow, alphabet) + out : out
-}
-
-// function to convert a string to a number based on the given alphabet
-// see example for toLetters
-function fromLetters(str, alphabet) {
-  let out = 0
-  const len = str.length
-  let pos = len
-  while (pos > 0) {
-    pos -= 1
-    out += alphabet.indexOf(str[pos]) * alphabet.length ** (len - 1 - pos)
-  }
-  return out
-}
-
-const alphaLower = "abcdef"
-const alphaMixed = "abcdefABCDEF"
+import {
+  toLetters,
+  fromLetters,
+  alphaLower,
+  alphaMixed,
+} from "../../util/password"
 
 export default function PasswordGuesser({ userInput, inputType }) {
   let genEnd

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -43,13 +43,20 @@ const guesser = (userInput, inputType) => {
 const timeDifference = (userInput1, userInput2, inputType) => {
   let duration1
   let duration2
+  let diffMsg
 
   if (inputType === "num") {
     duration1 = parseInt(userInput1, 10) / 100000
     duration2 = parseInt(userInput2, 10) / 100000
+    diffMsg = `With more digits in your password, the computer took
+      ${(duration2 / duration1).toFixed(1)}x as long to brute force your
+      password!`
   } else if (inputType === "alpha") {
     duration1 = fromLetters(userInput1, alphaLower) / 10000
     duration2 = fromLetters(userInput2, alphaMixed) / 10000
+    diffMsg = `With more variety in your password, the computer took
+      ${(duration2 / duration1).toFixed(1)}x as long to brute force your
+      password!`
   }
 
   return (
@@ -70,7 +77,6 @@ const timeDifference = (userInput1, userInput2, inputType) => {
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {formatTime(duration1)}
         </Typography1>
-        <Typography1>to brute force!</Typography1>
       </div>
       <div
         style={{
@@ -88,7 +94,16 @@ const timeDifference = (userInput1, userInput2, inputType) => {
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {formatTime(duration2)}
         </Typography1>
-        <Typography1>to brute force!</Typography1>
+      </div>
+      <div
+        style={{
+          padding: 4,
+          borderRadius: 4,
+          margin: 4,
+          border: "1px solid black",
+        }}
+      >
+        <Typography1>{diffMsg}</Typography1>
       </div>
     </>
   )

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -10,7 +10,12 @@ import Browser from "../components/Browser/Browser"
 import Comparison from "../components/Comparison/Comparison"
 import Chat from "../components/Chat/Chat"
 
-import { fromLetters, alphaLower, alphaMixed } from "../util/password"
+import {
+  fromLetters,
+  alphaLower,
+  alphaMixed,
+  formatTime,
+} from "../util/password"
 
 const Typography = withStyles((theme) => ({
   root: {
@@ -20,18 +25,19 @@ const Typography = withStyles((theme) => ({
   },
 }))(MuiTypography)
 
+const Typography1 = withStyles({
+  root: {
+    fontSize: "1em",
+    textAlign: "center",
+  },
+})(MuiTypography)
+
 const guesser = (userInput, inputType) => {
   return (
     <Box display="flex" flexDirection="column" alignItems="center">
       <PasswordGuesser userInput={userInput} inputType={inputType} />
     </Box>
   )
-}
-
-const formatTime = (num) => {
-  const min = Math.floor(num / 60)
-  const sec = num % 60
-  return min !== 0 ? `${String(min)}m ${sec.toFixed(5)}s` : `${sec.toFixed(5)}s`
 }
 
 const timeDifference = (userInput1, userInput2, inputType) => {
@@ -48,14 +54,42 @@ const timeDifference = (userInput1, userInput2, inputType) => {
 
   return (
     <>
-      <Typography style={{ textAlign: "center", paddingBottom: ".5em" }}>
-        Your first password was {userInput1}, taking {formatTime(duration1)} to
-        generate!
-      </Typography>
-      <Typography style={{ textAlign: "center", paddingBottom: ".5em" }}>
-        Your second password was {userInput2}, taking {formatTime(duration2)} to
-        generate!
-      </Typography>
+      <div
+        style={{
+          padding: 4,
+          borderRadius: 4,
+          margin: 4,
+          border: "1px solid black",
+        }}
+      >
+        <Typography1>Your first password was</Typography1>
+        <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
+          {userInput1}
+        </Typography1>
+        <Typography1>and took</Typography1>
+        <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
+          {formatTime(duration1)}
+        </Typography1>
+        <Typography1>to brute force!</Typography1>
+      </div>
+      <div
+        style={{
+          padding: 4,
+          borderRadius: 4,
+          margin: 4,
+          border: "1px solid black",
+        }}
+      >
+        <Typography1>Your second password was</Typography1>
+        <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
+          {userInput2}
+        </Typography1>
+        <Typography1>and took</Typography1>
+        <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
+          {formatTime(duration2)}
+        </Typography1>
+        <Typography1>to brute force!</Typography1>
+      </div>
     </>
   )
 }
@@ -246,7 +280,10 @@ export default [
     },
     {
       slide: (
-        <Typography>Take a look at the time comparison on the left!</Typography>
+        <Typography>
+          Take a look at the time comparison on the left! Not what you expected?
+          Try going back and submitting different values!
+        </Typography>
       ),
       timeDifference: true,
       phoneContent: (userInput1, userInput2) =>
@@ -386,7 +423,10 @@ export default [
     },
     {
       slide: (
-        <Typography>Take a look at the time comparison on the left!</Typography>
+        <Typography>
+          Take a look at the time comparison on the left! Not what you expected?
+          Try going back and submitting different values!
+        </Typography>
       ),
       timeDifference: true,
       phoneContent: (userInput1, userInput2) =>

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -18,14 +18,10 @@ const Typography = withStyles((theme) => ({
   },
 }))(MuiTypography)
 
-const guesser = (userInput, inputType, inputLength) => {
+const guesser = (userInput, inputType) => {
   return (
     <Box display="flex" flexDirection="column" alignItems="center">
-      <PasswordGuesser
-        userInput={userInput}
-        inputType={inputType}
-        inputLength={inputLength}
-      />
+      <PasswordGuesser userInput={userInput} inputType={inputType} />
     </Box>
   )
 }
@@ -163,6 +159,7 @@ export default [
         </Typography>
       ),
       input: true,
+      inputNum: 1,
       inputType: "num",
       inputDesc: "4 digits",
       inputLength: 4,
@@ -177,7 +174,6 @@ export default [
           guesser to generate your 4-digit password!
         </Typography>
       ),
-      usesInput: true,
       inputType: "num",
       inputLength: 4,
       phoneContent: guesser,
@@ -190,6 +186,7 @@ export default [
         </Typography>
       ),
       input: true,
+      inputNum: 2,
       inputType: "num",
       inputDesc: "6 to 12 digits",
       inputLength: -1,
@@ -209,7 +206,7 @@ export default [
         </Typography>
       ),
       inputType: "num",
-      usesInput: true,
+      usesInput2: true,
       inputLength: -1,
       phoneContent: guesser,
     },
@@ -290,6 +287,7 @@ export default [
         </Typography>
       ),
       input: true,
+      inputNum: 1,
       inputType: "alpha",
       inputDesc: "6 lowercase letters from (a b c d e f)",
       inputLength: 6,
@@ -304,7 +302,6 @@ export default [
           6-letter lowercase password!
         </Typography>
       ),
-      usesInput: true,
       inputType: "alpha",
       inputLength: 6,
       phoneContent: guesser,
@@ -319,6 +316,7 @@ export default [
         </Typography>
       ),
       input: true,
+      inputNum: 2,
       inputType: "Alpha",
       inputDesc: "6 letters from (a b c d e f), with at least 2 uppercase",
       inputLength: 6,
@@ -339,7 +337,7 @@ export default [
           6-letter mixed-case password!
         </Typography>
       ),
-      usesInput: true,
+      usesInput2: true,
       inputType: "Alpha",
       inputLength: 6,
       phoneContent: guesser,

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -10,6 +10,8 @@ import Browser from "../components/Browser/Browser"
 import Comparison from "../components/Comparison/Comparison"
 import Chat from "../components/Chat/Chat"
 
+import { fromLetters, alphaLower, alphaMixed } from "../util/password"
+
 const Typography = withStyles((theme) => ({
   root: {
     fontSize: "1em",
@@ -23,6 +25,38 @@ const guesser = (userInput, inputType) => {
     <Box display="flex" flexDirection="column" alignItems="center">
       <PasswordGuesser userInput={userInput} inputType={inputType} />
     </Box>
+  )
+}
+
+const formatTime = (num) => {
+  const min = Math.floor(num / 60)
+  const sec = num % 60
+  return min !== 0 ? `${String(min)}m ${sec.toFixed(5)}s` : `${sec.toFixed(5)}s`
+}
+
+const timeDifference = (userInput1, userInput2, inputType) => {
+  let duration1
+  let duration2
+
+  if (inputType === "num") {
+    duration1 = parseInt(userInput1, 10) / 100000
+    duration2 = parseInt(userInput2, 10) / 100000
+  } else if (inputType === "alpha") {
+    duration1 = fromLetters(userInput1, alphaLower) / 10000
+    duration2 = fromLetters(userInput2, alphaMixed) / 10000
+  }
+
+  return (
+    <>
+      <Typography style={{ textAlign: "center", paddingBottom: ".5em" }}>
+        Your first password was {userInput1}, taking {formatTime(duration1)} to
+        generate!
+      </Typography>
+      <Typography style={{ textAlign: "center", paddingBottom: ".5em" }}>
+        Your second password was {userInput2}, taking {formatTime(duration2)} to
+        generate!
+      </Typography>
+    </>
   )
 }
 
@@ -212,6 +246,14 @@ export default [
     },
     {
       slide: (
+        <Typography>Take a look at the time comparison on the left!</Typography>
+      ),
+      timeDifference: true,
+      phoneContent: (userInput1, userInput2) =>
+        timeDifference(userInput1, userInput2, "num"),
+    },
+    {
+      slide: (
         <>
           <Typography>
             Depending on exactly which numbers you picked for your passwords,
@@ -341,6 +383,14 @@ export default [
       inputType: "Alpha",
       inputLength: 6,
       phoneContent: guesser,
+    },
+    {
+      slide: (
+        <Typography>Take a look at the time comparison on the left!</Typography>
+      ),
+      timeDifference: true,
+      phoneContent: (userInput1, userInput2) =>
+        timeDifference(userInput1, userInput2, "alpha"),
     },
     {
       slide: (

--- a/src/constants/lessons.js
+++ b/src/constants/lessons.js
@@ -48,13 +48,13 @@ const timeDifference = (userInput1, userInput2, inputType) => {
   if (inputType === "num") {
     duration1 = parseInt(userInput1, 10) / 100000
     duration2 = parseInt(userInput2, 10) / 100000
-    diffMsg = `With more digits in your password, the computer took
+    diffMsg = `With more digits in your password, it would take
       ${(duration2 / duration1).toFixed(1)}x as long to brute force your
       password!`
   } else if (inputType === "alpha") {
     duration1 = fromLetters(userInput1, alphaLower) / 10000
     duration2 = fromLetters(userInput2, alphaMixed) / 10000
-    diffMsg = `With more variety in your password, the computer took
+    diffMsg = `With more variety in your password, it would take
       ${(duration2 / duration1).toFixed(1)}x as long to brute force your
       password!`
   }
@@ -73,10 +73,11 @@ const timeDifference = (userInput1, userInput2, inputType) => {
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {userInput1}
         </Typography1>
-        <Typography1>and took</Typography1>
+        <Typography1>and would take</Typography1>
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {formatTime(duration1)}
         </Typography1>
+        <Typography1>for our password generator to guess!</Typography1>
       </div>
       <div
         style={{
@@ -90,10 +91,11 @@ const timeDifference = (userInput1, userInput2, inputType) => {
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {userInput2}
         </Typography1>
-        <Typography1>and took</Typography1>
+        <Typography1>and would take</Typography1>
         <Typography1 style={{ fontFamily: "Monospace", fontSize: "1.5rem" }}>
           {formatTime(duration2)}
         </Typography1>
+        <Typography1>for our password generator to guess!</Typography1>
       </div>
       <div
         style={{
@@ -265,7 +267,7 @@ export default [
       slide: (
         <Typography>
           Wow, that was really fast! Now let’s try using a longer password!
-          Enter a password consisting of 6–12 digits.
+          Enter a password consisting of 6–8 digits.
         </Typography>
       ),
       input: true,
@@ -273,9 +275,9 @@ export default [
       inputType: "num",
       inputDesc: "6 to 12 digits",
       inputLength: -1,
-      checkInput: (str) => /^\d{6,12}$/.test(str),
+      checkInput: (str) => /^\d{6,8}$/.test(str),
       defaultInput: () => {
-        const len = randomInt(6, 12)
+        const len = randomInt(6, 8)
         return getRandom("0123456789", len)
       },
       phoneContent: inputForm,

--- a/src/util/password.js
+++ b/src/util/password.js
@@ -1,0 +1,32 @@
+// function to convert a number to a string based on the given alphabet
+//    example: if alphabet is 'abc',
+//      0 -> 'a'
+//      1 -> 'b'
+//      2 -> 'c'
+//      3 -> 'aa'
+//      4 -> 'ab'
+//      5 -> 'ac'
+//      6 -> 'ba'
+//      ...
+export const toLetters = (num, alphabet) => {
+  const mod = num % alphabet.length
+  const pow = Math.floor(num / alphabet.length)
+  const out = alphabet[mod]
+  return pow ? toLetters(pow, alphabet) + out : out
+}
+
+// function to convert a string to a number based on the given alphabet
+// see example for toLetters
+export const fromLetters = (str, alphabet) => {
+  let out = 0
+  const len = str.length
+  let pos = len
+  while (pos > 0) {
+    pos -= 1
+    out += alphabet.indexOf(str[pos]) * alphabet.length ** (len - 1 - pos)
+  }
+  return out
+}
+
+export const alphaLower = "abcdef"
+export const alphaMixed = "abcdefABCDEF"

--- a/src/util/password.js
+++ b/src/util/password.js
@@ -30,3 +30,25 @@ export const fromLetters = (str, alphabet) => {
 
 export const alphaLower = "abcdef"
 export const alphaMixed = "abcdefABCDEF"
+
+export const formatTime = (num) => {
+  const days = Math.floor(num / 86400)
+  const hours = Math.floor((num % 86400) / 3600)
+  const minutes = Math.floor((num % 3600) / 60)
+  const seconds = num % 60
+
+  let result = ""
+  if (days !== 0) {
+    result += `${days}d`
+  }
+  if (hours !== 0) {
+    result += `${hours}h `
+  }
+  if (minutes !== 0) {
+    result += `${minutes}m `
+  }
+  if (seconds !== 0) {
+    result += `${seconds.toFixed(5)}s`
+  }
+  return result
+}


### PR DESCRIPTION
Fixes #38 

This PR adds a time difference screen after the second password generator for lessons 1 and 2. I also implemented the ability to go back **within** a lesson, so the users can try submitting different values without having to start the lesson over.

![image](https://user-images.githubusercontent.com/35614552/86159147-e0c58f00-bad7-11ea-9ce0-537f0d84d813.png)
![image](https://user-images.githubusercontent.com/35614552/86159177-efac4180-bad7-11ea-95d4-2b698d7edcab.png)
