### PR TITLE
Implements Basic Create-Password Game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1335,6 +1335,30 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.56.tgz",
+      "integrity": "sha512-xPlkK+z/6y/24ka4gVJgwPfoCF4RCh8dXb1BNE7MtF9bXEBLN/lBxNTK8VAa0qm3V2oinA6xtUIdcRh0aeRtVw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.10.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.10.2",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.10.2.tgz",
+          "integrity": "sha512-eg29v74P7W5r6a4tWWDAAfZldXIzfyO1am2fIsC39hdUUHm/33k6pGOKPbgDjg/U/4ifmgAePy/1OjkKN6rFRw==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        }
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",
@@ -15257,6 +15281,11 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha1-KOwXzwl0PtyrBW3dixsGJizHPDA="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.10.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.56",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
@@ -16,7 +17,8 @@
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
-    "react-visibility-sensor": "^5.1.1"
+    "react-visibility-sensor": "^5.1.1",
+    "zxcvbn": "^4.4.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Main from "./components/Main/Main"
 import Landing from "./components/Landing/Landing"
 import End from "./components/End/End"
 import Game from "./components/Game/Game"
+import CreateGame from "./components/Game/Create"
 import ListOfCommonPasswords from "./components/ListOfCommonPasswords/ListOfCommonPasswords"
 
 const useStyles = makeStyles(() => ({
@@ -37,11 +38,11 @@ function App() {
           <Button color="inherit" onClick={() => sendTo("/activity")}>
             Activities
           </Button>
-          <Button color="inherit" onClick={() => sendTo("/game")}>
-            Password Game
-          </Button>
           <Button color="inherit" onClick={() => sendTo("/common")}>
             Most Common Passwords
+          </Button>
+          <Button color="inherit" onClick={() => sendTo("/game")}>
+            Password Games
           </Button>
         </Toolbar>
       </AppBar>
@@ -61,6 +62,9 @@ function App() {
         </Route>
         <Route path="/end">
           <End />
+        </Route>
+        <Route path="/game/create">
+          <CreateGame />
         </Route>
         <Route path="/game">
           <Game />

--- a/src/components/End/End.js
+++ b/src/components/End/End.js
@@ -1,13 +1,14 @@
+/* eslint-disable react/no-unescaped-entities */
 import React from "react"
-import Typography from "@material-ui/core/Typography"
+
+import { useHistory } from "react-router-dom"
+
+import { Box, Button, Container, Grid, Typography } from "@material-ui/core"
 import makeStyles from "@material-ui/core/styles/makeStyles"
-import Container from "@material-ui/core/Container"
-import Grid from "@material-ui/core/Grid"
 
 import FavoriteIcon from "@material-ui/icons/Favorite"
 import GitHubIcon from "@material-ui/icons/GitHub"
 
-import { Box } from "@material-ui/core"
 import { ReactComponent as CommonImg } from "./common.svg"
 import { ReactComponent as LengthImg } from "./length.svg"
 import { ReactComponent as SpiceImg } from "./spice.svg"
@@ -55,6 +56,7 @@ const cards = [
 
 export default function End() {
   const classes = useStyles()
+  const history = useHistory()
 
   const cardItems = cards.map((item) => {
     return (
@@ -99,29 +101,27 @@ export default function End() {
               variant="body1"
               style={{
                 textAlign: "center",
-                maxWidth: "800px",
+                maxWidth: "1000px",
                 marginLeft: "auto",
                 marginRight: "auto",
                 paddingTop: "20px",
               }}
             >
               Remember these tips when creating your own passwords! However, you
-              should also try to make your passwords memorable. You can still
-              use words, but capitalize some letters and put numbers and symbols
-              between them. For example, instead of using redcherries2015, you
-              could try something like chErr20iesRE?D
+              should also try to make your passwords memorable. If you can't
+              remember your password, then it's really useless!
             </Typography>
-            <Typography
-              variant="body1"
-              style={{
-                textAlign: "center",
-                maxWidth: "800px",
-                marginLeft: "auto",
-                marginRight: "auto",
-                paddingTop: "20px",
-              }}
-            >
-              If you want to get more advanced, try using a password manager!
+            <hr />
+            <Typography className={classes.header}>
+              Think you're a pro? Test your mettle in our Password Games!
+            </Typography>
+            <Button variant="contained" onClick={() => history.push("/game")}>
+              Password Games
+            </Button>
+            <hr />
+            <Typography style={{ paddingTop: "20px", textAlign: "center" }}>
+              We hope you really enjoyed this interactive learning lab - we had
+              a lot of fun making it!
             </Typography>
             <Typography style={{ paddingTop: "20px", textAlign: "center" }}>
               made with{" "}

--- a/src/components/Game/Create.js
+++ b/src/components/Game/Create.js
@@ -1,0 +1,145 @@
+/* eslint-disable react/no-unescaped-entities */
+import React, { useState } from "react"
+
+import makeStyles from "@material-ui/core/styles/makeStyles"
+import {
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Link,
+  TextField,
+  Typography,
+} from "@material-ui/core"
+import Alert from "@material-ui/lab/Alert"
+
+const zxcvbn = require("zxcvbn")
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    color: theme.palette.secondary.main,
+    fontFamily: theme.typography.fontFamily,
+    fontWeight: 600,
+    fontSize: "5rem",
+  },
+  subtitle: {
+    fontSize: "1.5rem",
+    padding: "1rem",
+  },
+}))
+
+function getTextScore(score) {
+  switch (score) {
+    case 0:
+      return "too guessable"
+    case 1:
+      return "very guessable"
+    case 2:
+      return "somewhat guessable"
+    case 3:
+      return "safely unguessable"
+    default:
+      return "very unguessable!"
+  }
+}
+
+function ZxcvbnResult(props) {
+  // eslint-disable-next-line react/prop-types
+  const { password } = props
+  if (password === "") {
+    return <></>
+  }
+  const res = zxcvbn(password)
+  // eslint-disable-next-line camelcase
+  const { guesses, crack_times_display, score, feedback } = res
+  const lowerBound = crack_times_display.offline_fast_hashing_1e10_per_second
+  const upperBound = crack_times_display.offline_slow_hashing_1e4_per_second
+  return (
+    <Card
+      variant="outlined"
+      style={{
+        maxWidth: 1000,
+        display: "block",
+        margin: "auto",
+        marginTop: "2rem",
+      }}
+    >
+      <CardContent>
+        <Typography variant="h5" component="h2">
+          {/* eslint-disable-next-line camelcase */}
+          Password Score: {getTextScore(score)}
+        </Typography>
+        <br />
+        <Typography color="textSecondary" gutterBottom>
+          It would take from <Chip color="secondary" label={lowerBound} /> to{" "}
+          <Chip color="secondary" label={upperBound} /> to crack your password.
+        </Typography>
+        <Typography color="textSecondary" gutterBottom>
+          The computer needs to make {guesses.toFixed(0)} guesses.
+        </Typography>
+        {feedback.warning && (
+          <Alert severity="warning">{feedback.warning}</Alert>
+        )}
+        <Typography color="textSecondary">
+          Feedback:
+          {feedback.suggestions.length > 0 ? (
+            <ul>
+              {feedback.suggestions.map((feedbackMsg) => (
+                <li>{feedbackMsg}</li>
+              ))}
+            </ul>
+          ) : (
+            " Looking good!"
+          )}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function CreateGame() {
+  const classes = useStyles()
+  const [testPass, setTestPass] = useState("")
+
+  const onTestPassChange = (e) => {
+    setTestPass(e.target.value)
+    console.log(zxcvbn(testPass))
+  }
+
+  return (
+    <Container maxWidth="lg">
+      <section className="hero is-fullheight">
+        <div className="hero-body">
+          <div>
+            <Typography variant="h1" component="h1" className={classes.title}>
+              A Moderately-Smart Password Checker
+            </Typography>
+            <Typography
+              variant="body1"
+              component="h2"
+              className={classes.subtitle}
+            >
+              Test your password making skills! Implements Dropbox's{" "}
+              <Link
+                href="https://github.com/dropbox/zxcvbn"
+                target="_blank"
+                rel="noopener noreferrer"
+                color="secondary"
+              >
+                zxcvbn package.
+              </Link>
+            </Typography>
+            <TextField
+              label="Type a Password!"
+              variant="outlined"
+              color="secondary"
+              value={testPass}
+              onChange={onTestPassChange}
+            />
+            <ZxcvbnResult password={testPass} />
+          </div>
+        </div>
+      </section>
+    </Container>
+  )
+}

--- a/src/components/Game/Game.js
+++ b/src/components/Game/Game.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
 import React from "react"
+import { useHistory } from "react-router-dom"
 
 import Typography from "@material-ui/core/Typography"
 import makeStyles from "@material-ui/core/styles/makeStyles"
@@ -30,7 +31,10 @@ const useStyles = makeStyles((theme) => ({
 
 export default function Game() {
   const classes = useStyles()
-
+  const history = useHistory()
+  const sendTo = (location) => {
+    history.push(location)
+  }
   return (
     <Container maxWidth="lg">
       <section className="hero is-fullheight">
@@ -54,7 +58,9 @@ export default function Game() {
               Let's test just how much of a pro you are.
             </Typography>
             <Button variant="contained">Pick the Best Password</Button>
-            <Button variant="contained">Create an Amazing Password</Button>
+            <Button variant="contained" onClick={() => sendTo("/game/create")}>
+              Create an Amazing Password
+            </Button>
           </div>
         </div>
       </section>

--- a/src/components/ListOfCommonPasswords/ListOfCommonPasswords.js
+++ b/src/components/ListOfCommonPasswords/ListOfCommonPasswords.js
@@ -23,15 +23,6 @@ const useStyles = makeStyles((theme) => ({
     fontSize: "1.5rem",
     padding: "1rem",
   },
-  start: {
-    fontSize: "2rem",
-    padding: "4px 40px",
-  },
-  img: {
-    [theme.breakpoints.down("sm")]: {
-      width: 0,
-    },
-  },
 }))
 
 export default function ListOfCommonPasswords() {


### PR DESCRIPTION
This PR implements a basic create password game, that tells users how secure any phrase they input is. It's half of #51 (I'd like to also create a Kahoot-style multiple choice game). Here's what I've done:

* created a new `/game/create` page which takes in a user-developed password and gives feedback on it (via `zxcvbn`): how strong it is, how long it would take to crack, and feedback/warnings on the password
* changes CTAs on main games page, end-of-activity slide to new games page
* import `zxcvbn` and `material-ui/labs` as npm dependencies

The entire thing definitely needs some more UI work (I'm also eyeing adding a progress bar to indicate password strength), but this is the MVP for our dry run w/ CityLab.

Preview: https://deploy-preview-56--stupefied-varahamihira-55e231.netlify.app/game/create